### PR TITLE
Replace custom sort with `sort -V`

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -18,8 +18,7 @@ if test -n "$GITHUB_API_TOKEN"; then
 fi
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+  sort -V
 }
 
 list_github_tags() {


### PR DESCRIPTION
The current sorting is sorting the new version (`10.0.0`) incorrectly:
```
$ mise ls-remote chezscheme
10.0.0
9.4
9.5
9.5.1
9.5.2
9.5.4
9.5.6
9.5.8
9.5.8a
9.6.0
9.6.2
9.6.4
```

Sorting can be fixed by replacing the custom sort implementation with the `sort` command's "version sort" capability:
![Screenshot from 2024-04-23 00-19-00](https://github.com/asdf-community/asdf-chezscheme/assets/2058614/929759da-4de6-4218-ba14-6d62299a2e60)
