### PR TITLE
Fix v10.0.0 failing to build before install

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -60,6 +60,7 @@ install_version() {
     (
       cd "$install_path/build"
       ./configure --installprefix="$install_path" "${ASDF_CHEZ_CONFIGURE_OPTS[@]:-${ASDF_CHEZ_DEFAULT_OPTS[@]}}"
+      make
       make install
     )
 


### PR DESCRIPTION
For whatever reason, Chez Scheme v10.0.0 does not build when `make install` is run. A `make` is added to ensure that happens.